### PR TITLE
Add prefix path handling

### DIFF
--- a/lib/groonga/command/base.rb
+++ b/lib/groonga/command/base.rb
@@ -40,12 +40,13 @@ module Groonga
       end
 
       attr_reader :name, :arguments
-      attr_accessor :original_format, :original_source
+      attr_accessor :original_format, :original_source, :prefix
       def initialize(name, pair_arguments, ordered_arguments=[])
         @name = name
         @arguments = construct_arguments(pair_arguments, ordered_arguments)
         @original_format = nil
         @original_source = nil
+        @prefix = "d"
       end
 
       def [](name)
@@ -80,7 +81,7 @@ module Groonga
       end
 
       def to_uri_format
-        Format::URI.new(@name, normalized_arguments).path
+        Format::URI.new(@prefix, @name, normalized_arguments).path
       end
 
       def to_command_format

--- a/lib/groonga/command/format/uri.rb
+++ b/lib/groonga/command/format/uri.rb
@@ -22,13 +22,14 @@ module Groonga
   module Command
     module Format
       class URI
-        def initialize(name, arguments)
+        def initialize(prefix, name, arguments)
+          @prefix = prefix
           @name = name
           @arguments = arguments
         end
 
         def path
-          path = "/d/#{@name}"
+          path = "/#{@prefix}/#{@name}"
           arguments = @arguments.dup
           output_type = arguments.delete(:output_type)
           path << ".#{output_type}" if output_type

--- a/test/command/test-base.rb
+++ b/test/command/test-base.rb
@@ -57,6 +57,15 @@ class BaseCommandTest < Test::Unit::TestCase
       assert_equal("/d/select.json?table=Users",
                    select.to_uri_format)
     end
+
+    def test_prefix
+      select = Groonga::Command::Base.new("select",
+                                          :table => "Users",
+                                          :output_type => "json")
+      select.prefix = "db1"
+      assert_equal("/db1/select.json?table=Users",
+                   select.to_uri_format)
+    end
   end
 
   class CovnertToCommandFormatTest < self


### PR DESCRIPTION
groonga-httpdのクライアントとしてgroonga-clientなんかを使うときに、内部でこういう感じにプレフィックスパスを指定できるといいかなーと思ったのですけども、どうでしょう？
