### PR TITLE
Add Base#to_elasticsearch_format

### DIFF
--- a/lib/groonga/command/base.rb
+++ b/lib/groonga/command/base.rb
@@ -1,4 +1,5 @@
 # Copyright (C) 2012-2017  Kouhei Sutou <kou@clear-code.com>
+# Copyright (C) 2019 Yasuhiro Horimoto <horimoto@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,6 +17,7 @@
 
 require "groonga/command/format/uri"
 require "groonga/command/format/command"
+require "groonga/command/format/elasticsearch"
 
 module Groonga
   module Command
@@ -151,6 +153,11 @@ module Groonga
       def to_command_format(options={})
         format = Format::Command.new(@command_name, normalized_arguments)
         format.command_line(options)
+      end
+
+      def to_elasticsearch_format
+        format = Format::Elasticsearch.new(@command_name, normalized_arguments)
+        format.command_line
       end
 
       def to_s

--- a/lib/groonga/command/base.rb
+++ b/lib/groonga/command/base.rb
@@ -157,7 +157,7 @@ module Groonga
 
       def to_elasticsearch_format(options={})
         format = Format::Elasticsearch.new(@command_name, normalized_arguments)
-        format.command_line(options)
+        format.json(options)
       end
 
       def to_s

--- a/lib/groonga/command/base.rb
+++ b/lib/groonga/command/base.rb
@@ -155,9 +155,9 @@ module Groonga
         format.command_line(options)
       end
 
-      def to_elasticsearch_format
+      def to_elasticsearch_format(options={})
         format = Format::Elasticsearch.new(@command_name, normalized_arguments)
-        format.command_line
+        format.command_line(options)
       end
 
       def to_s

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -40,13 +40,12 @@ module Groonga
             case name
             when :table
               case elasticsearch_version
-              when 5, 6
-                header = {"index"=>{"_index"=>"#{value.downcase}", "_type"=>"groonga"}}
               when 7
                 header = {"index"=>{"_index"=>"#{value.downcase}", "_type"=>"_doc"}}
               when 8
                 header = {"index"=>{"_index"=>"#{value.downcase}"}}
               else
+                # Version 5.x or 6.x
                 header = {"index"=>{"_index"=>"#{value.downcase}", "_type"=>"groonga"}}
               end
               components << JSON.generate(header) + "\n"

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -56,7 +56,7 @@ module Groonga
                   column_names.each_with_index do |column_name, i|
                     body.merge!({"#{column_name}"=>"#{column_values[i]}"})
                   end
-                    components << JSON.generate(body) + "\n"
+                  components << JSON.generate(body) + "\n"
                 end
               else
                 JSON.parse(value).each do |load_value|

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -61,7 +61,7 @@ module Groonga
               record = JSON.parse(value)
               if record[0].is_a?(::Array)
                 is_column_namse = true
-                column_names = []
+                column_names = nil
 
                 record.each do |load_value|
                   if is_column_namse
@@ -69,7 +69,7 @@ module Groonga
                     is_column_namse = false
                     next
                   end
-                  column_values = []
+                  column_values = nil
                   column_values = load_value
                   column_names.each_with_index do |column_name, i|
                     body.merge!({"#{column_name}"=>"#{column_values[i]}"})

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -61,7 +61,7 @@ module Groonga
               components << JSON.generate(header) + "\n"
             when :values
               record = JSON.parse(value)
-              if record.first.to_s.start_with?("[")
+              if record[0].is_a?(::Array)
                 is_first = true
                 column_names = []
                 column_values = []

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -26,7 +26,7 @@ module Groonga
           return if @name != "load"
 
           body = {}
-          components = ""
+          components = []
           elasticsearch_version = options[:version] || 5
 
           sorted_arguments = @arguments.sort_by do |name, _|
@@ -58,7 +58,7 @@ module Groonga
                   }
                 }
               end
-              components << JSON.generate(header) + "\n"
+              components << JSON.generate(header)
             when :values
               record = JSON.parse(value)
               if record[0].is_a?(::Array)
@@ -76,19 +76,19 @@ module Groonga
                   column_names.each_with_index do |column_name, i|
                     body.merge!({"#{column_name}"=>"#{column_values[i]}"})
                   end
-                  components << JSON.generate(body) + "\n"
+                  components << JSON.generate(body)
                 end
               else
                 record.each do |load_value|
                   load_value.keys.each do |key|
                     body.merge!({"#{key}"=>"#{load_value[key]}"})
                   end
-                  components << JSON.generate(body) + "\n"
+                  components << JSON.generate(body)
                 end
               end
             end
           end
-          components.chomp!
+          components.join("\n")
         end
       end
     end

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -29,9 +29,7 @@ module Groonga
           components = []
           elasticsearch_version = options[:version] || 5
 
-          sorted_arguments = @arguments.sort_by do |name, _|
-            name.to_s
-          end
+          sorted_arguments = @arguments.sort_by(&:first)
           sorted_arguments.each do |name, value|
             case name
             when :table

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -60,13 +60,13 @@ module Groonga
               end
               components << JSON.generate(header) + "\n"
             when :values
-              json_value = JSON.parse(value)
-              if json_value.first.to_s.start_with?("[")
+              record = JSON.parse(value)
+              if record.first.to_s.start_with?("[")
                 is_first = true
                 column_names = []
                 column_values = []
 
-                json_value.each do |load_value|
+                record.each do |load_value|
                   if is_first
                     column_names = load_value
                     is_first = false
@@ -79,7 +79,7 @@ module Groonga
                   components << JSON.generate(body) + "\n"
                 end
               else
-                json_value.each do |load_value|
+                record.each do |load_value|
                   load_value.keys.each do |key|
                     body.merge!({"#{key}"=>"#{load_value[key]}"})
                   end

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -69,7 +69,6 @@ module Groonga
                     column_names = load_value
                     next
                   end
-                  column_values = nil
                   column_values = load_value
                   column_names.zip(column_values) do |column_name, column_value|
                     body[column_name] = column_value

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -25,7 +25,6 @@ module Groonga
         def json(options={})
           return if @name != "load"
 
-          body = {}
           components = []
           elasticsearch_version = options[:version] || 5
 
@@ -58,10 +57,12 @@ module Groonga
               end
               components << JSON.generate(header)
             when :values
+              body = {}
               record = JSON.parse(value)
-              if record[0].is_a?(::Array)
 
+              if record[0].is_a?(::Array)
                 column_names = nil
+
                 record.each do |load_value|
                   if column_names.nil?
                     column_names = load_value
@@ -70,14 +71,14 @@ module Groonga
                   column_values = nil
                   column_values = load_value
                   column_names.each_with_index do |column_name, i|
-                    body.merge!({"#{column_name}"=>"#{column_values[i]}"})
+                    body[column_name] = column_values[i]
                   end
                   components << JSON.generate(body)
                 end
               else
                 record.each do |load_value|
                   load_value.keys.each do |key|
-                    body.merge!({"#{key}"=>"#{load_value[key]}"})
+                    body[key] = load_value[key]
                   end
                   components << JSON.generate(body)
                 end

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -25,7 +25,7 @@ module Groonga
         def json(options={})
           return if @name != "load"
 
-          body = Hash.new
+          body = {}
           components = ""
           elasticsearch_version = options[:version]
 

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -27,7 +27,7 @@ module Groonga
 
           body = {}
           components = ""
-          elasticsearch_version = options[:version]
+          elasticsearch_version = options[:version] || 5
 
           sorted_arguments = @arguments.sort_by do |name, _|
             name.to_s

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -25,7 +25,6 @@ module Groonga
         def json(options={})
           return if @name != "load"
 
-          header = Hash.new
           body = Hash.new
           components = ""
           elasticsearch_version = options[:version]

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -70,8 +70,8 @@ module Groonga
                   end
                   column_values = nil
                   column_values = load_value
-                  column_names.each_with_index do |column_name, i|
-                    body[column_name] = column_values[i]
+                  column_names.zip(column_values) do |column_name, column_value|
+                    body[column_name] = column_value
                   end
                   components << JSON.generate(body)
                 end

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -62,14 +62,14 @@ module Groonga
             when :values
               record = JSON.parse(value)
               if record[0].is_a?(::Array)
-                is_first = true
+                is_column_namse = true
                 column_names = []
                 column_values = []
 
                 record.each do |load_value|
-                  if is_first
+                  if is_column_namse
                     column_names = load_value
-                    is_first = false
+                    is_column_namse = false
                     next
                   end
                   column_values = load_value

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
 module Groonga
   module Command
     module Format

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -1,0 +1,76 @@
+# Copyright (C) 2019  Yasuhiro Horimoto <horimoto@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require "English"
+
+module Groonga
+  module Command
+    module Format
+      class Elasticsearch
+        def initialize(name, arguments)
+          @name = name
+          @arguments = arguments
+        end
+
+        def command_line
+          return if @name != "load"
+
+          header = Hash.new
+          body = Hash.new
+          components = ""
+
+          sorted_arguments = @arguments.sort_by do |name, _|
+            name.to_s
+          end
+          sorted_arguments.each do |name, value|
+            case name
+            when :table
+              header = {"index"=>{"_index"=>"groonga", "_type"=>"#{value}"}}
+              components << JSON.generate(header) + "\n"
+            when :values
+              if JSON.parse(value).first.to_s.start_with?("[")
+                is_first = true
+                column_names = []
+                column_values = []
+
+                JSON.parse(value).each do |load_value|
+                  if is_first
+                    column_names = load_value
+                    is_first = false
+                    next
+                  end
+                  column_values = load_value
+                  column_names.each_with_index do |column_name, i|
+                    body.merge!({"#{column_name}"=>"#{column_values[i]}"})
+                  end
+                    components << JSON.generate(body) + "\n"
+                end
+              else
+                JSON.parse(value).each do |load_value|
+                  load_value.keys.each do |key|
+                    body.merge!({"#{key}"=>"#{load_value[key]}"})
+                  end
+                  components << JSON.generate(body) + "\n"
+                end
+              end
+            end
+          end
+          components.chomp!
+        end
+      end
+    end
+  end
+end

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -77,10 +77,7 @@ module Groonga
                 end
               else
                 record.each do |load_value|
-                  load_value.keys.each do |key|
-                    body[key] = load_value[key]
-                  end
-                  components << JSON.generate(body)
+                  components << JSON.generate(load_value)
                 end
               end
             end

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -41,12 +41,13 @@ module Groonga
               header = {"index"=>{"_index"=>"groonga", "_type"=>"#{value}"}}
               components << JSON.generate(header) + "\n"
             when :values
-              if JSON.parse(value).first.to_s.start_with?("[")
+              json_value = JSON.parse(value)
+              if json_value.first.to_s.start_with?("[")
                 is_first = true
                 column_names = []
                 column_values = []
 
-                JSON.parse(value).each do |load_value|
+                json_value.each do |load_value|
                   if is_first
                     column_names = load_value
                     is_first = false
@@ -59,7 +60,7 @@ module Groonga
                   components << JSON.generate(body) + "\n"
                 end
               else
-                JSON.parse(value).each do |load_value|
+                json_value.each do |load_value|
                   load_value.keys.each do |key|
                     body.merge!({"#{key}"=>"#{load_value[key]}"})
                   end

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -37,12 +37,26 @@ module Groonga
             when :table
               case elasticsearch_version
               when 7
-                header = {"index"=>{"_index"=>"#{value.downcase}", "_type"=>"_doc"}}
+                header = {
+                  "index" => {
+                    "_index" => value.downcase,
+                    "_type"=>"_doc",
+                  }
+                }
               when 8
-                header = {"index"=>{"_index"=>"#{value.downcase}"}}
+                header = {
+                  "index" => {
+                    "_index" => value.downcase,
+                  }
+                }
               else
                 # Version 5.x or 6.x
-                header = {"index"=>{"_index"=>"#{value.downcase}", "_type"=>"groonga"}}
+                header = {
+                  "index" => {
+                    "_index" => value.downcase,
+                    "_type" => "groonga",
+                  }
+                }
               end
               components << JSON.generate(header) + "\n"
             when :values

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -13,9 +13,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-require "English"
-
 module Groonga
   module Command
     module Format

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -22,7 +22,7 @@ module Groonga
           @arguments = arguments
         end
 
-        def command_line(options={})
+        def json(options={})
           return if @name != "load"
 
           header = Hash.new

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -60,13 +60,11 @@ module Groonga
             when :values
               record = JSON.parse(value)
               if record[0].is_a?(::Array)
-                is_column_namse = true
-                column_names = nil
 
+                column_names = nil
                 record.each do |load_value|
-                  if is_column_namse
+                  if column_names.nil?
                     column_names = load_value
-                    is_column_namse = false
                     next
                   end
                   column_values = nil

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -62,7 +62,6 @@ module Groonga
               if record[0].is_a?(::Array)
                 is_column_namse = true
                 column_names = []
-                column_values = []
 
                 record.each do |load_value|
                   if is_column_namse
@@ -70,6 +69,7 @@ module Groonga
                     is_column_namse = false
                     next
                   end
+                  column_values = []
                   column_values = load_value
                   column_names.each_with_index do |column_name, i|
                     body.merge!({"#{column_name}"=>"#{column_values[i]}"})

--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -23,7 +23,7 @@ module Groonga
         end
 
         def json(options={})
-          return if @name != "load"
+          return nil unless @name == "load"
 
           components = []
           elasticsearch_version = options[:version] || 5

--- a/test/command/test-base.rb
+++ b/test/command/test-base.rb
@@ -214,8 +214,8 @@ select \\
 
     def setup
       @load = Groonga::Command::Base.new("load",
-                                        :table => "Site",
-                                        :values => <<-VALUES)
+                                         :table => "Site",
+                                         :values => <<-VALUES)
 [
 ["_key","title"],
 ["http://example.org/","This is test record 1!"]

--- a/test/command/test-base.rb
+++ b/test/command/test-base.rb
@@ -213,76 +213,37 @@ select \\
     end
 
     sub_test_case("options") do
-      def test_options_elasticsearch_version_5
-        load = Groonga::Command::Base.new("load",
-                                          :table => "Site",
-                                          :values => <<-VALUES)
-  [
-  ["_key","title"],
-  ["http://example.org/","This is test record 1!"]
-  ]
-        VALUES
-
-        expected = <<-OUTPUT
+      expections = {}
+      expections[:version5] = <<-OUTPUT
 {"index":{"_index":"site","_type":"groonga"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
-        OUTPUT
-
-        assert_equal(expected.chomp, load.to_elasticsearch_format(:version=>5))
-      end
-
-      def test_options_elasticsearch_version_6
-        load = Groonga::Command::Base.new("load",
-                                          :table => "Site",
-                                          :values => <<-VALUES)
-  [
-  ["_key","title"],
-  ["http://example.org/","This is test record 1!"]
-  ]
-        VALUES
-
-        expected = <<-OUTPUT
-{"index":{"_index":"site","_type":"groonga"}}
-{"_key":"http://example.org/","title":"This is test record 1!"}
-        OUTPUT
-
-        assert_equal(expected.chomp, load.to_elasticsearch_format(:version=>6))
-      end
-
-      def test_options_elasticsearch_version_7
-        load = Groonga::Command::Base.new("load",
-                                          :table => "Site",
-                                          :values => <<-VALUES)
-  [
-  ["_key","title"],
-  ["http://example.org/","This is test record 1!"]
-  ]
-        VALUES
-
-        expected = <<-OUTPUT
+      OUTPUT
+      expections[:version6] = expections[:version5]
+      expections[:version7] = <<-OUTPUT
 {"index":{"_index":"site","_type":"_doc"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
-        OUTPUT
-
-        assert_equal(expected.chomp, load.to_elasticsearch_format(:version=>7))
-      end
-
-      def test_options_elasticsearch_version_8
-        load = Groonga::Command::Base.new("load",
-                                          :table => "Site",
-                                          :values => <<-VALUES)
-  [
-  ["_key","title"],
-  ["http://example.org/","This is test record 1!"]
-  ]
-        VALUES
-
-        expected = <<-OUTPUT
+      OUTPUT
+      expections[:version8] = <<-OUTPUT
 {"index":{"_index":"site"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
-        OUTPUT
+      OUTPUT
 
-        assert_equal(expected.chomp, load.to_elasticsearch_format(:version=>8))
+      load = Groonga::Command::Base.new("load",
+                                        :table => "Site",
+                                        :values => <<-VALUES)
+[
+["_key","title"],
+["http://example.org/","This is test record 1!"]
+]
+      VALUES
+
+      data("version 5" => [expections[:version5], load, :version=>5],
+           "version 6" => [expections[:version6], load, :version=>6],
+           "version 7" => [expections[:version7], load, :version=>7],
+           "version 8" => [expections[:version8], load, :version=>8])
+      def test_options_elasticsearch_version(data)
+        expected, target, version = data
+        assert_equal(expected.chomp, target.to_elasticsearch_format(version))
       end
     end
   end

--- a/test/command/test-base.rb
+++ b/test/command/test-base.rb
@@ -237,10 +237,10 @@ select \\
 ]
       VALUES
 
-      data("version 5" => [expections[:version5], load, :version=>5],
-           "version 6" => [expections[:version6], load, :version=>6],
-           "version 7" => [expections[:version7], load, :version=>7],
-           "version 8" => [expections[:version8], load, :version=>8])
+      data("version 5" => [expections[:version5], load, :version => 5],
+           "version 6" => [expections[:version6], load, :version => 6],
+           "version 7" => [expections[:version7], load, :version => 7],
+           "version 8" => [expections[:version8], load, :version => 8])
       def test_options_elasticsearch_version(data)
         expected, target, version = data
         assert_equal(expected.chomp, target.to_elasticsearch_format(version))

--- a/test/command/test-base.rb
+++ b/test/command/test-base.rb
@@ -123,7 +123,7 @@ select \\
   end
 
   class CovnertToElasticsearchFormatTest < self
-    sub_test_case("non_target_command") do
+    sub_test_case("non target command") do
       def test_select_command
         select = Groonga::Command::Base.new("select",
                                             :table => "Users",
@@ -134,7 +134,7 @@ select \\
       end
     end
 
-    sub_test_case("single_record") do
+    sub_test_case("single record") do
       def test_brackets_format
         load = Groonga::Command::Base.new("load",
                                           :table => "Site",
@@ -171,7 +171,7 @@ select \\
       end
     end
 
-    sub_test_case("multiple_records") do
+    sub_test_case("multiple records") do
       def test_brackets_format
         load = Groonga::Command::Base.new("load",
                                           :table => "Site",

--- a/test/command/test-base.rb
+++ b/test/command/test-base.rb
@@ -145,12 +145,12 @@ select \\
   ]
         VALUES
 
-        expected = <<-OUTPUT
+        expected = <<-OUTPUT.chomp
 {"index":{"_index":"site","_type":"groonga"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
         OUTPUT
 
-        assert_equal(expected.chomp, load.to_elasticsearch_format)
+        assert_equal(expected, load.to_elasticsearch_format)
       end
 
       def test_curly_brackets_format
@@ -162,12 +162,12 @@ select \\
   ]
         VALUES
 
-        expected = <<-OUTPUT
+        expected = <<-OUTPUT.chomp
 {"index":{"_index":"site","_type":"groonga"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
         OUTPUT
 
-        assert_equal(expected.chomp, load.to_elasticsearch_format)
+        assert_equal(expected, load.to_elasticsearch_format)
       end
     end
 
@@ -183,13 +183,13 @@ select \\
   ]
         VALUES
 
-        expected = <<-OUTPUT
+        expected = <<-OUTPUT.chomp
 {"index":{"_index":"site","_type":"groonga"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
 {"_key":"http://example.net/","title":"This is test record 2!"}
         OUTPUT
 
-        assert_equal(expected.chomp, load.to_elasticsearch_format)
+        assert_equal(expected, load.to_elasticsearch_format)
       end
 
       def test_curly_brackets_format
@@ -202,28 +202,28 @@ select \\
   ]
         VALUES
 
-        expected = <<-OUTPUT
+        expected = <<-OUTPUT.chomp
 {"index":{"_index":"site","_type":"groonga"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
 {"_key":"http://example.net/","title":"This is test record 2!"}
         OUTPUT
 
-        assert_equal(expected.chomp, load.to_elasticsearch_format)
+        assert_equal(expected, load.to_elasticsearch_format)
       end
     end
 
     sub_test_case("options") do
       expections = {}
-      expections[:version5] = <<-OUTPUT
+      expections[:version5] = <<-OUTPUT.chomp
 {"index":{"_index":"site","_type":"groonga"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
       OUTPUT
       expections[:version6] = expections[:version5]
-      expections[:version7] = <<-OUTPUT
+      expections[:version7] = <<-OUTPUT.chomp
 {"index":{"_index":"site","_type":"_doc"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
       OUTPUT
-      expections[:version8] = <<-OUTPUT
+      expections[:version8] = <<-OUTPUT.chomp
 {"index":{"_index":"site"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
       OUTPUT
@@ -243,7 +243,7 @@ select \\
            "version 8" => [expections[:version8], load, :version => 8])
       def test_options_elasticsearch_version(data)
         expected, target, version = data
-        assert_equal(expected.chomp, target.to_elasticsearch_format(version))
+        assert_equal(expected, target.to_elasticsearch_format(version))
       end
     end
   end

--- a/test/command/test-base.rb
+++ b/test/command/test-base.rb
@@ -212,23 +212,8 @@ select \\
       end
     end
 
-    sub_test_case("options") do
-      expections = {}
-      expections[:version5] = <<-OUTPUT.chomp
-{"index":{"_index":"site","_type":"groonga"}}
-{"_key":"http://example.org/","title":"This is test record 1!"}
-      OUTPUT
-      expections[:version6] = expections[:version5]
-      expections[:version7] = <<-OUTPUT.chomp
-{"index":{"_index":"site","_type":"_doc"}}
-{"_key":"http://example.org/","title":"This is test record 1!"}
-      OUTPUT
-      expections[:version8] = <<-OUTPUT.chomp
-{"index":{"_index":"site"}}
-{"_key":"http://example.org/","title":"This is test record 1!"}
-      OUTPUT
-
-      load = Groonga::Command::Base.new("load",
+    def setup
+      @load = Groonga::Command::Base.new("load",
                                         :table => "Site",
                                         :values => <<-VALUES)
 [
@@ -236,14 +221,35 @@ select \\
 ["http://example.org/","This is test record 1!"]
 ]
       VALUES
+    end
 
-      data("version 5" => [expections[:version5], load, :version => 5],
-           "version 6" => [expections[:version6], load, :version => 6],
-           "version 7" => [expections[:version7], load, :version => 7],
-           "version 8" => [expections[:version8], load, :version => 8])
-      def test_options_elasticsearch_version(data)
-        expected, target, version = data
-        assert_equal(expected, target.to_elasticsearch_format(version))
+    sub_test_case(":version") do
+      def test_5
+        assert_equal(<<-REQUESTS.chomp, @load.to_elasticsearch_format(:version => 5))
+{"index":{"_index":"site","_type":"groonga"}}
+{"_key":"http://example.org/","title":"This is test record 1!"}
+        REQUESTS
+      end
+
+      def test_6
+        assert_equal(<<-REQUESTS.chomp, @load.to_elasticsearch_format(:version => 6))
+{"index":{"_index":"site","_type":"groonga"}}
+{"_key":"http://example.org/","title":"This is test record 1!"}
+        REQUESTS
+      end
+
+      def test_7
+        assert_equal(<<-REQUESTS.chomp, @load.to_elasticsearch_format(:version => 7))
+{"index":{"_index":"site","_type":"_doc"}}
+{"_key":"http://example.org/","title":"This is test record 1!"}
+        REQUESTS
+      end
+
+      def test_8
+        assert_equal(<<-REQUESTS.chomp, @load.to_elasticsearch_format(:version => 8))
+{"index":{"_index":"site"}}
+{"_key":"http://example.org/","title":"This is test record 1!"}
+        REQUESTS
       end
     end
   end

--- a/test/command/test-base.rb
+++ b/test/command/test-base.rb
@@ -144,9 +144,13 @@ select \\
   ["http://example.org/","This is test record 1!"]
   ]
         VALUES
-        assert_equal("{\"index\":{\"_index\":\"groonga\",\"_type\":\"Site\"}}\n" +
-                     "{\"_key\":\"http://example.org/\",\"title\":\"This is test record 1!\"}",
-                     load.to_elasticsearch_format)
+
+        expected = <<-OUTPUT
+{"index":{"_index":"groonga","_type":"Site"}}
+{"_key":"http://example.org/","title":"This is test record 1!"}
+        OUTPUT
+
+        assert_equal(expected.chomp, load.to_elasticsearch_format)
       end
 
       def test_curly_brackets_format
@@ -157,9 +161,13 @@ select \\
   {"_key": "http://example.org/", "title": "This is test record 1!"}
   ]
         VALUES
-        assert_equal("{\"index\":{\"_index\":\"groonga\",\"_type\":\"Site\"}}\n" +
-                     "{\"_key\":\"http://example.org/\",\"title\":\"This is test record 1!\"}",
-                     load.to_elasticsearch_format)
+
+        expected = <<-OUTPUT
+{"index":{"_index":"groonga","_type":"Site"}}
+{"_key":"http://example.org/","title":"This is test record 1!"}
+        OUTPUT
+
+        assert_equal(expected.chomp, load.to_elasticsearch_format)
       end
     end
 
@@ -174,10 +182,14 @@ select \\
   ["http://example.net/","This is test record 2!"]
   ]
         VALUES
-        assert_equal("{\"index\":{\"_index\":\"groonga\",\"_type\":\"Site\"}}\n" +
-                     "{\"_key\":\"http://example.org/\",\"title\":\"This is test record 1!\"}\n" +
-                     "{\"_key\":\"http://example.net/\",\"title\":\"This is test record 2!\"}",
-                     load.to_elasticsearch_format)
+
+        expected = <<-OUTPUT
+{"index":{"_index":"groonga","_type":"Site"}}
+{"_key":"http://example.org/","title":"This is test record 1!"}
+{"_key":"http://example.net/","title":"This is test record 2!"}
+        OUTPUT
+
+        assert_equal(expected.chomp, load.to_elasticsearch_format)
       end
 
       def test_curly_brackets_format
@@ -189,10 +201,14 @@ select \\
   {"_key": "http://example.net/", "title": "This is test record 2!"}
   ]
         VALUES
-        assert_equal("{\"index\":{\"_index\":\"groonga\",\"_type\":\"Site\"}}\n" +
-                     "{\"_key\":\"http://example.org/\",\"title\":\"This is test record 1!\"}\n" +
-                     "{\"_key\":\"http://example.net/\",\"title\":\"This is test record 2!\"}",
-                     load.to_elasticsearch_format)
+
+        expected = <<-OUTPUT
+{"index":{"_index":"groonga","_type":"Site"}}
+{"_key":"http://example.org/","title":"This is test record 1!"}
+{"_key":"http://example.net/","title":"This is test record 2!"}
+        OUTPUT
+
+        assert_equal(expected.chomp, load.to_elasticsearch_format)
       end
     end
   end

--- a/test/command/test-base.rb
+++ b/test/command/test-base.rb
@@ -146,7 +146,7 @@ select \\
         VALUES
 
         expected = <<-OUTPUT
-{"index":{"_index":"groonga","_type":"Site"}}
+{"index":{"_index":"site","_type":"groonga"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
         OUTPUT
 
@@ -163,7 +163,7 @@ select \\
         VALUES
 
         expected = <<-OUTPUT
-{"index":{"_index":"groonga","_type":"Site"}}
+{"index":{"_index":"site","_type":"groonga"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
         OUTPUT
 
@@ -184,7 +184,7 @@ select \\
         VALUES
 
         expected = <<-OUTPUT
-{"index":{"_index":"groonga","_type":"Site"}}
+{"index":{"_index":"site","_type":"groonga"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
 {"_key":"http://example.net/","title":"This is test record 2!"}
         OUTPUT
@@ -203,12 +203,86 @@ select \\
         VALUES
 
         expected = <<-OUTPUT
-{"index":{"_index":"groonga","_type":"Site"}}
+{"index":{"_index":"site","_type":"groonga"}}
 {"_key":"http://example.org/","title":"This is test record 1!"}
 {"_key":"http://example.net/","title":"This is test record 2!"}
         OUTPUT
 
         assert_equal(expected.chomp, load.to_elasticsearch_format)
+      end
+    end
+
+    sub_test_case("options") do
+      def test_options_elasticsearch_version_5
+        load = Groonga::Command::Base.new("load",
+                                          :table => "Site",
+                                          :values => <<-VALUES)
+  [
+  ["_key","title"],
+  ["http://example.org/","This is test record 1!"]
+  ]
+        VALUES
+
+        expected = <<-OUTPUT
+{"index":{"_index":"site","_type":"groonga"}}
+{"_key":"http://example.org/","title":"This is test record 1!"}
+        OUTPUT
+
+        assert_equal(expected.chomp, load.to_elasticsearch_format(:version=>5))
+      end
+
+      def test_options_elasticsearch_version_6
+        load = Groonga::Command::Base.new("load",
+                                          :table => "Site",
+                                          :values => <<-VALUES)
+  [
+  ["_key","title"],
+  ["http://example.org/","This is test record 1!"]
+  ]
+        VALUES
+
+        expected = <<-OUTPUT
+{"index":{"_index":"site","_type":"groonga"}}
+{"_key":"http://example.org/","title":"This is test record 1!"}
+        OUTPUT
+
+        assert_equal(expected.chomp, load.to_elasticsearch_format(:version=>6))
+      end
+
+      def test_options_elasticsearch_version_7
+        load = Groonga::Command::Base.new("load",
+                                          :table => "Site",
+                                          :values => <<-VALUES)
+  [
+  ["_key","title"],
+  ["http://example.org/","This is test record 1!"]
+  ]
+        VALUES
+
+        expected = <<-OUTPUT
+{"index":{"_index":"site","_type":"_doc"}}
+{"_key":"http://example.org/","title":"This is test record 1!"}
+        OUTPUT
+
+        assert_equal(expected.chomp, load.to_elasticsearch_format(:version=>7))
+      end
+
+      def test_options_elasticsearch_version_8
+        load = Groonga::Command::Base.new("load",
+                                          :table => "Site",
+                                          :values => <<-VALUES)
+  [
+  ["_key","title"],
+  ["http://example.org/","This is test record 1!"]
+  ]
+        VALUES
+
+        expected = <<-OUTPUT
+{"index":{"_index":"site"}}
+{"_key":"http://example.org/","title":"This is test record 1!"}
+        OUTPUT
+
+        assert_equal(expected.chomp, load.to_elasticsearch_format(:version=>8))
       end
     end
   end


### PR DESCRIPTION
This commit convert Groonga's dump format to Elasticsearch's import format as below.

```
table_create Site TABLE_HASH_KEY ShortText
column_create Site title COLUMN_SCALAR ShortText

table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto

load --table Site
[
["_key","title"],
["http://example.org/","This is test record 1!"],
["http://example.net/","test record 2."]
]

column_create Terms blog_title COLUMN_INDEX|WITH_POSITION Site title
```
↓
```
{ "index" : { "_index" : "groonga", "_type" : "Site" } }
{ "_key": "http://example.org/", "title": "This is test record 1!"}
{ "index" : { "_index" : "groonga", "_type" : "Site" } }
{ "_key": "http://example.net/", "title": "test record 2."}
```

For example, bulk insert to Elasticserch:
```
curl -X POST "localhost:9200/_bulk" -H 'Content-Type: application/json' -d'
{ "index" : { "_index" : "groonga", "_type" : "Site" } }
{ "_key": "http://example.org/", "title": "This is test record 1!"}
{ "index" : { "_index" : "groonga", "_type" : "Site" } }
{ "_key": "http://example.net/", "title": "test record 2."}
```