### PR TITLE
Use "columns" parameter

### DIFF
--- a/lib/groonga/command/format/elasticsearch.rb
+++ b/lib/groonga/command/format/elasticsearch.rb
@@ -27,6 +27,7 @@ module Groonga
           return nil unless @name == "load"
 
           components = []
+          column_names = []
           elasticsearch_version = options[:version] || 5
 
           sorted_arguments = @arguments.sort_by(&:first)
@@ -57,17 +58,15 @@ module Groonga
                 }
               end
               components << JSON.generate(header)
+            when :columns
+              value.split(",").each do |column_name|
+                column_names << column_name
+              end
             when :values
               record = JSON.parse(value)
 
               if record[0].is_a?(::Array)
-                column_names = nil
-
                 record.each do |load_value|
-                  if column_names.nil?
-                    column_names = load_value
-                    next
-                  end
                   body = {}
                   column_values = load_value
                   column_names.zip(column_values) do |column_name, column_value|

--- a/test/command/test-base.rb
+++ b/test/command/test-base.rb
@@ -138,9 +138,9 @@ select \\
       def test_brackets_format
         load = Groonga::Command::Base.new("load",
                                           :table => "Site",
+                                          :columns => "_key,title",
                                           :values => <<-VALUES)
   [
-  ["_key","title"],
   ["http://example.org/","This is test record 1!"]
   ]
         VALUES
@@ -175,9 +175,9 @@ select \\
       def test_brackets_format
         load = Groonga::Command::Base.new("load",
                                           :table => "Site",
+                                          :columns => "_key,title",
                                           :values => <<-VALUES)
   [
-  ["_key","title"],
   ["http://example.org/","This is test record 1!"],
   ["http://example.net/","This is test record 2!"]
   ]
@@ -215,9 +215,9 @@ select \\
     def setup
       @load = Groonga::Command::Base.new("load",
                                          :table => "Site",
+                                         :columns =>"_key,title",
                                          :values => <<-VALUES)
 [
-["_key","title"],
 ["http://example.org/","This is test record 1!"]
 ]
       VALUES


### PR DESCRIPTION
Fix to use `columns` parameter as with https://github.com/groonga/groonga-command-parser/pull/3/commits/67fa684db5abd5f5182a6d949b982c5ed3dacb97