### PR TITLE
Use cgi/escape

### DIFF
--- a/lib/groonga/command/format/uri.rb
+++ b/lib/groonga/command/format/uri.rb
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (C) 2012-2014  Kouhei Sutou <kou@clear-code.com>
+# Copyright (C) 2012-2025  Sutou Kouhei <kou@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,7 +14,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-require "cgi"
+require "cgi/escape"
 
 module Groonga
   module Command


### PR DESCRIPTION
cgi isn't bundled in Ruby 3.5.